### PR TITLE
Add prj.open before prj.build

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,4 +7,5 @@
   , "indent": 4
   , "unused": "vars"
   , "latedef": "nofunc"
+  , "esnext": true
 }

--- a/src/build.js
+++ b/src/build.js
@@ -2,8 +2,6 @@
 
 /******************************************************************************/
 
-var path = require('path');
-
 // This should be eventaually replaced with
 // var IosProject = require('cordova-ios');
 var cordovaLib = require('cordova-lib');
@@ -15,7 +13,10 @@ exports = module.exports = function build(prjInfo) {
     // Requires: prjInfo.paths.www
 
     let proj = new IosProject();
-    return proj.build(prjInfo);
-}
+    return proj.open(prjInfo.paths.root)
+        .then(() => {
+            return proj.build();
+        });
+};
 
 /******************************************************************************/

--- a/src/create.js
+++ b/src/create.js
@@ -1,4 +1,7 @@
 'use strict';
+var path = require('path');
+var cordovaLib = require('cordova-lib');
+var IosProject = cordovaLib.IosProject;
 
 /******************************************************************************/
 


### PR DESCRIPTION
For now the PlatformProject object is not usable before it's initialized with either open() or init()
Maybe we need to add the convenience of automatically opening the project as part of build() if it's not yet initialized but it's not there yet.